### PR TITLE
Updated the tutorial on the ospool guest account to have most up-to-d…

### DIFF
--- a/pelicanFS.ipynb
+++ b/pelicanFS.ipynb
@@ -7,50 +7,52 @@
    "source": [
     "# PelicanFS\n",
     "\n",
-    "Pelican provides the Python package `pelicanfs`, which enables the transfer of objects via the `pelican://` protocol from inside of Python.\n",
-    "For information on the implementation, see the Github repository at [github.com/pelicanplatform/pelicanfs](https://github.com/pelicanplatform/pelicanfs).\n",
+    "PelicanFS is a filesystem specification (fsspec) implementation for the Pelican Platform. It provides a Python interface to interact with Pelican federations, allowing you to read, write, and manage objects across distributed storage systems.\n",
     "\n",
-    "The `pelicanfs` package can be installed via `pip`, i.e.,\n",
-    "\n",
+    "**Installation:**\n",
     "```bash\n",
-    "python3 -m pip install pelicanfs\n",
+    "pip install pelicanfs\n",
     "```\n",
     "\n",
     "**The `pelicanfs` package comes pre-installed in the Guest OSPool Notebook!**\n",
     "\n",
-    "## Manual import and setup\n",
-    "\n",
-    "The main method for using `pelicanfs` is to use the `PelicanFileSystem` class.\n",
-    "First, import this from `pelicanfs` as follows:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "a43719a5-a8d2-4297-8349-60105293d015",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pelicanfs.core import PelicanFileSystem"
+    "For comprehensive documentation, see the [PelicanFS README](https://github.com/PelicanPlatform/pelicanfs)."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3ac4e876-66e3-4230-b7c3-ed281a45fcf1",
+   "id": "b558f939",
    "metadata": {},
    "source": [
-    "Next, instantiate the an object of the class for a particular Federation.\n",
-    "For this example, we'll continue using the OSDF Federation, which has the Federation URL of `osg-htc.org`:"
+    "## Setup\n",
+    "\n",
+    "There are three ways to use PelicanFS:\n",
+    "\n",
+    "1. **PelicanFileSystem** - Connect to any Pelican federation by providing its discovery URL\n",
+    "2. **OSDFFileSystem** - Convenience class that automatically connects to OSDF (osg-htc.org)\n",
+    "3. **fsspec directly** - Use the `osdf://` or `pelican://` schemes with fsspec\n",
+    "\n",
+    "Here, we instantiate three objects to demonstrate the use, which we will use for the rest of the tutorial. All three use the OSDF Federation, which has the Federation URL of `osg-htc.org`:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "5b71c352-635b-4c9b-abf7-4f7877d6a059",
+   "execution_count": null,
+   "id": "a43719a5-a8d2-4297-8349-60105293d015",
    "metadata": {},
    "outputs": [],
    "source": [
-    "pelfs = PelicanFileSystem('pelican://osg-htc.org')"
+    "from pelicanfs import PelicanFileSystem, OSDFFileSystem\n",
+    "import fsspec\n",
+    "\n",
+    "# Option 1: PelicanFileSystem with explicit federation URL\n",
+    "pelfs = PelicanFileSystem('pelican://osg-htc.org')\n",
+    "\n",
+    "# Option 2: OSDFFileSystem (equivalent to above for OSDF)\n",
+    "osdf = OSDFFileSystem()\n",
+    "\n",
+    "# Option 3: fsspec with scheme\n",
+    "fs = fsspec.filesystem('osdf')"
    ]
   },
   {
@@ -58,14 +60,7 @@
    "id": "b6101b97-8f2d-42d7-add4-790571366d27",
    "metadata": {},
    "source": [
-    "For using the OSDF specifically, you can also do\n",
-    "\n",
-    "```python\n",
-    "from pelicanfs.core import OSDFFileSystem\n",
-    "pelfs = OSDFFileSystem()\n",
-    "```\n",
-    "\n",
-    "The `pelfs` object has methods for interacting with objects via the Federation.\n",
+    "These file system objects have methods for interacting with objects via the Federation.\n",
     "Usage typically looks like\n",
     "\n",
     "```python\n",
@@ -85,18 +80,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "4b9ae178-d514-4688-97b4-cd74d450ef5d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[{'name': '/pelicanplatform/test/hello-world.txt', 'size': None, 'type': 'file'}, {'name': '/pelicanplatform/test/hello-world.txt.md5', 'size': None, 'type': 'file'}]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "ls_results = pelfs.ls('/pelicanplatform/test')\n",
     "print(ls_results)"
@@ -104,20 +91,96 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "37de1759-496f-4fdd-adbf-a4e88e6fd816",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['/pelicanplatform/test/hello-world.txt', '/pelicanplatform/test/hello-world.txt.md5']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print([i['name'] for i in ls_results])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94c47caa",
+   "metadata": {},
+   "source": [
+    "## Pattern Matching with Glob\n",
+    "\n",
+    "Use `glob()` to find objects matching a pattern:\n",
+    "\n",
+    "> **Note:** Glob operations with `**` patterns can be expensive for large namespaces. Consider using `maxdepth` to limit the search."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c794bff0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "txt_files = pelfs.glob('/pelicanplatform/test/*.txt')\n",
+    "print(txt_files)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b80bb71",
+   "metadata": {},
+   "source": [
+    "## Reading Objects\n",
+    "\n",
+    "There are several ways to read object contents:\n",
+    "\n",
+    "**Using `cat()`** - Read contents directly into memory as bytes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43b7f700",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "content = pelfs.cat('/pelicanplatform/test/hello-world.txt')\n",
+    "print(content.decode('utf-8'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fcccda4",
+   "metadata": {},
+   "source": [
+    "**Using `open()`** - Get a file-like object for reading:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f7027b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with pelfs.open('/pelicanplatform/test/hello-world.txt', 'r') as f:\n",
+    "    print(f.read())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc5364b4",
+   "metadata": {},
+   "source": [
+    "You can also use `fsspec.open()` directly as long as you pass in the correct scheme:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2e807f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with fsspec.open('osdf:///pelicanplatform/test/hello-world.txt', 'r') as f:\n",
+    "    print(f.read())"
    ]
   },
   {
@@ -125,47 +188,29 @@
    "id": "21052a57-53ce-46c5-b577-f779115565cb",
    "metadata": {},
    "source": [
-    "## Getting objects\n",
+    "## Downloading Objects\n",
     "\n",
-    "Download an object using the `get` method."
+    "Use `get()` to download objects to local files.\n",
+    "\n",
+    "> **Note:** `cat()` and `open()` load data into memory for processing. `get()` saves objects as local files for persistent storage. When using `open()`, fsspec may store objects temporarily and clean them up when Python exits."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "85f96786-3b98-407e-be99-1c8f89642944",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[None]"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "pelfs.get('/pelicanplatform/test/hello-world.txt', 'hello-world.txt')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "67c1fcf1-248a-4c46-ad98-0f5d0367d788",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If you are seeing this message, getting an object from OSDF was successful.\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with open('hello-world.txt', 'r') as f:\n",
     "    my_file = f.read()\n",
@@ -183,37 +228,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "cef35e97-a0df-402f-8247-2efb248ec504",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "If you are seeing this message, getting an object from OSDF was successful.\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with pelfs.open('/pelicanplatform/test/hello-world.txt', 'r') as f:\n",
     "    direct_read = f.read()\n",
     "\n",
     "print(direct_read)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "c90db6fa-3560-49ba-9b8c-ed9474e2d9a2",
-   "metadata": {},
-   "source": [
-    "The `fsspec` module has an algorithm for deciding where to temporarily store objects.\n",
-    "It may decide to keep it in memory (RAM), or it may decide to write it to disk somewhere.\n",
-    "When the Python process exits, `fsspec` will clean up after itself **and remove the temporary objects**!\n",
-    "\n",
-    "If you want the data to be accessible locally after exiting the program, you should use the explicit `pelfs.get()`\n",
-    "command to save it locally."
    ]
   },
   {
@@ -231,24 +254,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "8a10b588-12c9-407c-8ac5-bfcc59e3d605",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "import pandas as pd\n",
-      "\n",
-      "station_URL='osdf:///aws-opendata/us-east-1/noaa-ghcn-pds/csv/by_station/USW00014837.csv'\n",
-      "\n",
-      "station_df = pd.read_csv(station_URL, low_memory=False)\n",
-      "print(station_df.head())\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bash\n",
     "cat autoload.py"
@@ -256,23 +265,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "79a46d8f-ffe6-41b4-b139-89cf77048250",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "            ID      DATE ELEMENT  DATA_VALUE M_FLAG Q_FLAG S_FLAG  OBS_TIME\n",
-      "0  USW00014837  19391001    TMAX         194    NaN    NaN      X       NaN\n",
-      "1  USW00014837  19391002    TMAX         211    NaN    NaN      X       NaN\n",
-      "2  USW00014837  19391003    TMAX         233    NaN    NaN      X       NaN\n",
-      "3  USW00014837  19391004    TMAX         272    NaN    NaN      X       NaN\n",
-      "4  USW00014837  19391005    TMAX         211    NaN    NaN      X       NaN\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%%bash\n",
     "python3 ./autoload.py"
@@ -280,13 +276,136 @@
   },
   {
    "cell_type": "markdown",
+   "id": "aaba4cde",
+   "metadata": {},
+   "source": [
+    "## Authorization\n",
+    "\n",
+    "PelicanFS supports token-based authorization for accessing protected namespaces and performing write operations.\n",
+    "\n",
+    "### Providing a Token via Headers\n",
+    "\n",
+    "You can explicitly provide an authorization token when creating the filesystem:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d93c0eb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: Using a Bearer token with PelicanFileSystem\n",
+    "# pelfs_auth = PelicanFileSystem(\n",
+    "#     'pelican://osg-htc.org',\n",
+    "#     headers={'Authorization': 'Bearer YOUR_TOKEN_HERE'}\n",
+    "# )\n",
+    "\n",
+    "# Example: Using a Bearer token with fsspec\n",
+    "# fs_auth = fsspec.filesystem('osdf', headers={'Authorization': 'Bearer YOUR_TOKEN_HERE'})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ac4c84c",
+   "metadata": {},
+   "source": [
+    "### Environment Variables\n",
+    "\n",
+    "PelicanFS automatically discovers tokens from environment variables:\n",
+    "\n",
+    "- `BEARER_TOKEN` - Direct token value\n",
+    "- `BEARER_TOKEN_FILE` - Path to a file containing the token"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13ada595",
+   "metadata": {},
+   "source": [
+    "### OAuth in Jupyter Notebooks\n",
+    "\n",
+    "When using OAuth authentication in Jupyter notebooks, you need special handling for password input because Jupyter handles stdin differently than a terminal:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "161e8b5f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import getpass\n",
+    "import sys\n",
+    "from io import StringIO\n",
+    "\n",
+    "# Capture the password securely\n",
+    "password = getpass.getpass(\"Enter password to encrypt credentials file: \")\n",
+    "\n",
+    "# Redirect stdin to provide the password\n",
+    "old_stdin = sys.stdin\n",
+    "sys.stdin = StringIO(password + \"\\n\")\n",
+    "\n",
+    "try:\n",
+    "    # Replace with your protected namespace path\n",
+    "    result = pelfs.ls(\"/your/protected/namespace/path\")\n",
+    "    print(result)\n",
+    "finally:\n",
+    "    sys.stdin = old_stdin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "88d05e45-cc46-4c50-9a3f-8c42ca568111",
    "metadata": {},
    "source": [
-    "## Putting objects\n",
+    "### Writing Objects\n",
     "\n",
-    "At this time, the `pelicanfs` package does not support authenticated requests, but it is under active development.\n",
-    "Stay tuned to [https://github.com/PelicanPlatform/pelicanfs](https://github.com/PelicanPlatform/pelicanfs) for updates!"
+    "To upload local files as objects, you need proper authorization:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "34bd5a60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: Upload a file (requires authorization)\n",
+    "# pelfs_auth.put('/local/path/file.txt', '/namespace/remote/path/object.txt')\n",
+    "\n",
+    "# Using fsspec\n",
+    "# fs_auth.put('/local/path/file.txt', '/namespace/remote/path/object.txt')\n",
+    "\n",
+    "# Upload multiple files recursively\n",
+    "# pelfs_auth.put('/local/directory/', '/namespace/remote/path/', recursive=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17191b7d",
+   "metadata": {},
+   "source": [
+    "## Limitations\n",
+    "\n",
+    "PelicanFS does not support the following operations (they will raise `NotImplementedError`):\n",
+    "\n",
+    "- `rm` (remove objects)\n",
+    "- `cp` (copy objects within the federation)\n",
+    "- `mkdir` / `makedirs` (create collections)\n",
+    "- `open()` with write modes - use `put()` instead"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25401cd3",
+   "metadata": {},
+   "source": [
+    "## Next Steps\n",
+    "\n",
+    "For more advanced usage, see:\n",
+    "\n",
+    "- **[PelicanFS README](https://github.com/PelicanPlatform/pelicanfs)** - Full documentation including xarray, PyTorch, and pandas integrations"
    ]
   }
  ],


### PR DESCRIPTION
…ate information

Note that the environemnt on the ospool needs to have an upgraded pelicanfs version for this notebook to function properly (which I'm unsure how to do. It's starts up as `1.0.2` whereas you want `1.3.0`. It would be nice if it didn't require the user to use pip install pelicanfs --upgrade